### PR TITLE
Update led.js

### DIFF
--- a/led.js
+++ b/led.js
@@ -92,6 +92,6 @@ Led.prototype.trigger = function(val) { // optional!
 
 // private
 Led.prototype.writeFile = function(fileName, val) {
-  return fs.writeFileSync(ledRootPath + this.name + '/' + fileName, val);
+  return fs.writeFileSync(ledRootPath + this.name + '/' + fileName, val.toString());
 };
 


### PR DESCRIPTION
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (255)
    at Object.writeFileSync (node:fs:2200:5)
    at Led.writeFile (/test/node_modules/led/led.js:95:13)
    at Led.brightness (/test/node_modules/led/led.js:43:15)
    at Led.on (/test/node_modules/led/led.js:20:8)
    at /test/index.js:9:19
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/test/index.js:7:12)
    at Module._compile (node:internal/modules/cjs/loader:1126:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at Module.load (node:internal/modules/cjs/loader:1004:32) {
  code: 'ERR_INVALID_ARG_TYPE'
}

This error comes up when we use "writeFileSync" with data as number